### PR TITLE
Relay control

### DIFF
--- a/frontend/src/components/SequencesList.tsx
+++ b/frontend/src/components/SequencesList.tsx
@@ -17,7 +17,9 @@ const SequencesList = () => {
   return (
     <div className="sequences-list">
       {Array.from(runIds).map(([runId, runInfos]) => (
-        <div className="sequenses-entry">{runId}</div>
+        <div className="sequenses-entry" key={runId}>
+          {runId}
+        </div>
       ))}
     </div>
   );

--- a/frontend/src/utils/MQTTConnection.ts
+++ b/frontend/src/utils/MQTTConnection.ts
@@ -329,7 +329,7 @@ class MQTTConnector {
           s.testruns.set(sourceId, testrun);
         });
         break;
-      case "run_ids":
+      case "run_ids": {
         const runIds = (data as RunIds).map((entry) => entry[0]);
         VosekastStore.update((s) => {
           for (const runId of runIds) {
@@ -345,6 +345,7 @@ class MQTTConnector {
           }
         });
         break;
+      }
     }
   };
 
@@ -369,5 +370,7 @@ class MQTTConnector {
 }
 
 // export singleton for reusing of the connection
-const MQTTConnection = new MQTTConnector(`ws://${window.location.hostname}:9001`);
+const MQTTConnection = new MQTTConnector(
+  `ws://${window.location.hostname}:9001`
+);
 export default MQTTConnection;

--- a/test/test_scale.py
+++ b/test/test_scale.py
@@ -12,12 +12,8 @@ class TestScale:
     def test_init(self, scale):
         assert isinstance(scale, Scale)
 
-    def test_start(self, scale):
-        scale.start()
-        assert scale.state == scale.RUNNING
-
     @pytest.mark.asyncio
-    async def test_stop(self, scale):
+    async def test_start_and_stop(self, scale):
         scale.start()
         assert scale.state == scale.RUNNING
 

--- a/test/test_tank.py
+++ b/test/test_tank.py
@@ -1,3 +1,4 @@
+import asyncio
 from vosekast_control.Tank import Tank
 from unittest.mock import MagicMock
 import pytest
@@ -41,8 +42,13 @@ class TestTank:
 
     @pytest.mark.asyncio
     async def test_fill(self, tank: Tank):
-        await tank.fill()
-        assert tank.vosekast.prepare_measuring.called
+        async def wait():
+            await asyncio.sleep(1)
+            tank._state = tank.FILLED
+
+        await asyncio.gather(tank.fill(), wait())
+
+        assert tank.source_pump.stop.called
 
     def test__on_draining(self, tank: Tank):
         tank._on_draining()

--- a/test/test_valve.py
+++ b/test/test_valve.py
@@ -12,7 +12,9 @@ class TestValve:
         valve_type = Valve.TWO_WAY
         regulation = Valve.BINARY
 
-        valve = Valve(vosekast, "test_valve", control_pin, valve_type, regulation, gpio_controller)
+        valve = Valve(
+            vosekast, "test_valve", control_pin, valve_type, regulation, gpio_controller
+        )
 
         return valve
 

--- a/vosekast_control/I2cInputAndRelayControl.py
+++ b/vosekast_control/I2cInputAndRelayControl.py
@@ -28,17 +28,18 @@ class RelayControl():
 
     
     def get_state_list(self):
-        n = 0
-        bin_string = "{0:b}".format(self.binary)
-        for n in range(8) :
-            self.state_dict[n]= bin_string[7-n]
+        bin_string = format(self.binary, '07b')
+        n = len(bin_string)
+        for digit in bin_string:
+            self.state_dict[n]= int(digit)
+            n -= 1
 
         return self.state_dict
 
 
-    def read_state(self):
+    def read_state(self): # Schaltet alles ein
         # return state as read from the bus
-        self.state_read = self.bus.read_byte_data(self.address_relays, 0)
+        self.state_read = self.bus.read_byte(self.address_relays)
         return self.state_read
 
 

--- a/vosekast_control/I2cInputAndRelayControl.py
+++ b/vosekast_control/I2cInputAndRelayControl.py
@@ -1,0 +1,52 @@
+import smbus
+import time
+bus = 
+address_relays = 0x38
+address_inputs = 0x39
+
+
+class RelayControl():
+
+    def __init__(self):
+        self.address_relays = 0x38
+        self.bus = smbus.SMBus(1)
+        self.state_list = []
+        self.read_state = None
+        self.binary = 255  # Represents relay address and inverted state in binary e.g. 0b11110101 -> relay 2 and 4 are "on"
+
+    def relays_on(self, relay_list):
+        
+        for relay in relay_list:
+            self.binary = self.binary & ~ 2**(relay-1)
+
+
+    def relays_off(self, relay_list):
+        
+        for relay in relay_list:
+            self.binary = self.binary | 2**(relay-1)
+
+    
+    def get_state_list(self):
+        n = 0
+        self.state_list = []
+        bin_string = "{0:b}".format(self.binary)
+        for n in range(8) :
+            self.state_list.append(bin_string[7-n])
+
+
+    def read_state(self):
+        # return state as read from the bus
+        self.read_state = self.bus.read_byte_data(self.address_relays, 0)
+        return self.read_state
+
+
+    def all_off(self):
+        self.binary = 255
+        self.switch()
+
+    def all_on(self):
+        self.binary = 0
+        self.switch()
+
+    def switch():
+        self.bus.write_byte_data(self.address_relays, 0, self.binary)

--- a/vosekast_control/I2cInputAndRelayControl.py
+++ b/vosekast_control/I2cInputAndRelayControl.py
@@ -1,9 +1,5 @@
 import smbus
 import time
-bus = 
-address_relays = 0x38
-address_inputs = 0x39
-
 
 class RelayControl():
 
@@ -11,8 +7,9 @@ class RelayControl():
         self.address_relays = 0x38
         self.bus = smbus.SMBus(1)
         self.state_list = []
-        self.read_state = None
+        self.state_read = None
         self.binary = 255  # Represents relay address and inverted state in binary e.g. 0b11110101 -> relay 2 and 4 are "on"
+
 
     def relays_on(self, relay_list):
         
@@ -33,20 +30,24 @@ class RelayControl():
         for n in range(8) :
             self.state_list.append(bin_string[7-n])
 
+        return self.state_list
+
 
     def read_state(self):
         # return state as read from the bus
-        self.read_state = self.bus.read_byte_data(self.address_relays, 0)
-        return self.read_state
+        self.state_read = self.bus.read_byte_data(self.address_relays, 0)
+        return self.state_read
 
 
     def all_off(self):
         self.binary = 255
         self.switch()
 
+
     def all_on(self):
         self.binary = 0
         self.switch()
 
-    def switch():
+
+    def switch(self):
         self.bus.write_byte_data(self.address_relays, 0, self.binary)

--- a/vosekast_control/I2cInputAndRelayControl.py
+++ b/vosekast_control/I2cInputAndRelayControl.py
@@ -6,7 +6,7 @@ class RelayControl():
     def __init__(self):
         self.address_relays = 0x38
         self.bus = smbus.SMBus(1)
-        self.state_list = []
+        self.state_dict = {}
         self.state_read = None
         self.binary = 255  # Represents relay address and inverted state in binary e.g. 0b11110101 -> relay 2 and 4 are "on"
 
@@ -15,6 +15,8 @@ class RelayControl():
         
         for relay in relay_list:
             self.binary = self.binary & ~ 2**(relay-1)
+        
+        self._flash()
 
 
     def relays_off(self, relay_list):
@@ -22,15 +24,16 @@ class RelayControl():
         for relay in relay_list:
             self.binary = self.binary | 2**(relay-1)
 
+        self._flash()
+
     
     def get_state_list(self):
         n = 0
-        self.state_list = []
         bin_string = "{0:b}".format(self.binary)
         for n in range(8) :
-            self.state_list.append(bin_string[7-n])
+            self.state_dict[n]= bin_string[7-n]
 
-        return self.state_list
+        return self.state_dict
 
 
     def read_state(self):
@@ -41,13 +44,13 @@ class RelayControl():
 
     def all_off(self):
         self.binary = 255
-        self.switch()
+        self._flash()
 
 
     def all_on(self):
         self.binary = 0
-        self.switch()
+        self._flash()
 
 
-    def switch(self):
+    def _flash(self):
         self.bus.write_byte_data(self.address_relays, 0, self.binary)

--- a/vosekast_control/I2cInputAndRelayControl.py
+++ b/vosekast_control/I2cInputAndRelayControl.py
@@ -6,7 +6,6 @@ class RelayControl:
     def __init__(self, address=0x38):
         self.address = address
         self.bus = smbus.SMBus(1)
-        self.state_reading = None
         self.state_binary = 255  # Represents relay address and inverted state in binary e.g. 0b11110101 -> relay 2 and 4 are "on"
 
     def relays_on(self, relay_list: List[int]):
@@ -33,8 +32,7 @@ class RelayControl:
 
     def read_state(self):
         # return state as read from the bus
-        self.state_reading = self.bus.read_byte(self.address)
-        return self.state_reading
+        return self.bus.read_byte(self.address)
 
     def all_off(self):
         self.state_binary = 255
@@ -48,7 +46,7 @@ class RelayControl:
         self.bus.write_byte_data(self.address, 0, self.state_binary)
 
 
-class I2CInput:
+class ReadDigitalInput:
     def __init__(self, address=0x39):
         self.address = address
         self.bus = smbus.SMBus(1)

--- a/vosekast_control/I2cInputAndRelayControl.py
+++ b/vosekast_control/I2cInputAndRelayControl.py
@@ -1,8 +1,8 @@
 import smbus
+from typing import Dict, List
 
 
-class RelayControl():
-
+class RelayControl:
     def __init__(self):
         self.address_relays = 0x38
         self.bus = smbus.SMBus(1)
@@ -10,69 +10,61 @@ class RelayControl():
         self.state_reading = None
         self.binary = 255  # Represents relay address and inverted state in binary e.g. 0b11110101 -> relay 2 and 4 are "on"
 
-
-    def relays_on(self, relay_list):
-        
-        for relay in relay_list:
-            self.binary = self.binary & ~ 2**(relay-1)
-        
-        self._flash()
-
-
-    def relays_off(self, relay_list):
+    def relays_on(self, relay_list: List[int]):
 
         for relay in relay_list:
-            self.binary = self.binary | 2**(relay-1)
+            self.binary = self.binary & ~(2 ** (relay - 1))
 
         self._flash()
 
-    
-    def get_state_dict(self):
-        bin_state = format(self.binary, '07b')
+    def relays_off(self, relay_list: List[int]):
+
+        for relay in relay_list:
+            self.binary = self.binary | 2 ** (relay - 1)
+
+        self._flash()
+
+    def get_state_dict(self) -> Dict[int, int]:
+        bin_state = format(self.binary, "07b")
         n = len(bin_state)
         for digit in bin_state:
-            self.state_dict[n]= int(digit)
+            self.state_dict[n] = 1 ^ int(digit)
             n -= 1
 
         return self.state_dict
-
 
     def read_state(self):
         # return state as read from the bus
         self.state_reading = self.bus.read_byte(self.address_relays)
         return self.state_reading
 
-
     def all_off(self):
         self.binary = 255
         self._flash()
-
 
     def all_on(self):
         self.binary = 0
         self._flash()
 
-
     def _flash(self):
         self.bus.write_byte_data(self.address_relays, 0, self.binary)
 
 
-class I2CInput():
-
+class I2CInput:
     def __init__(self):
         self.address_input = 0x39
         self.bus = smbus.SMBus(1)
         self.state_reading = None
 
-    def _read_state(self):
+    def _read_state(self) -> int:
         self.state_reading = self.bus.read_byte(self.address_input)
         return self.state_reading
 
-    def digitalRead(self, pin):
+    def digitalRead(self, pin: int) -> int:
         bin_state = self._read_state()
-        
-        if pin >= 8 or pin <= 0:
-            raise Exception("Pin is out of Range. Valid Pins are 1-7")
 
-        pin_state = (1 & (bin_state >> (pin-1)))
+        if pin >= 9 or pin <= 0:
+            raise Exception("Pin is out of Range. Valid Pins are 1-8")
+
+        pin_state = 1 ^ (1 & (bin_state >> (pin - 1)))
         return pin_state

--- a/vosekast_control/Tank.py
+++ b/vosekast_control/Tank.py
@@ -88,7 +88,7 @@ class Tank:
         else:
             self._on_draining()
 
-    async def fill(self, keep_source_active=False):
+    async def fill(self, keep_source_active=False, max_filling_time=75):
         if self._state == self.FILLED:
             self.logger.info(f"{self.name} already filled. Continuing.")
             return
@@ -117,8 +117,8 @@ class Tank:
                     datetime.now() - start_filling_time
                 ).total_seconds()
 
-                # if filling takes longer than 90s
-                if delta_time_filling >= 75 and not self.emulate:
+                # if filling takes longer than max_filling_time in sek
+                if delta_time_filling >= max_filling_time:
                     self.logger.error(
                         "Filling takes too long. Please make sure that all valves are closed and the pump is working. Aborting."
                     )


### PR DESCRIPTION
Added support for I2C base I/O extension. 7 Relays can now be controlled and their state can be read using a PCF8574 (RelayControl Class). Also I/O input can now be read through another PCF8574 (I2CInput class). I2C-addresses of the PCF8574 is hard coded.